### PR TITLE
Add media query to styledImgPreview component - relates #42

### DIFF
--- a/src/components/StyledImgPreview.jsx
+++ b/src/components/StyledImgPreview.jsx
@@ -3,6 +3,10 @@ import styled from "styled-components";
 const StyledImgPreview = styled.img`
   width: 100%;
   max-width: 90%;
+
+  @media screen and (max-width: 860px) {
+    max-width: 70%;
+  }
 `;
 
 export default StyledImgPreview;


### PR DESCRIPTION
* Added media query to target smaller devices like tablets and phones and limit the image width to 70% of its container.